### PR TITLE
feat: lazy load map component

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,22 +8,51 @@ import ExperienciasSection from "@/components/ExperienciasSection";
 import ParceirosSection from "@/components/ParceirosSection";
 import CtaComunidade from "@/components/CtaComunidade";
 import Footer from "@/components/Footer";
-import MapaInterativo from "@/components/MapaInterativo";
+import { Suspense, lazy, useEffect, useRef, useState } from "react";
+
+const MapaInterativo = lazy(() => import("@/components/MapaInterativo"));
 
 const Index = () => {
+  const [isMapVisible, setIsMapVisible] = useState(false);
+  const mapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsMapVisible(true);
+            observer.disconnect();
+          }
+        });
+      },
+      { threshold: 0.1 }
+    );
+
+    if (mapRef.current) {
+      observer.observe(mapRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <div className="min-h-screen">
       <Header />
       <Hero />
       <ViagensGrupo />
-      
+
       <HistoriasComunidade />
       <ConstruaViagem />
-      <div className="container mx-auto px-4 py-16">
+      <div className="container mx-auto px-4 py-16" ref={mapRef}>
         <h2 className="text-3xl font-bold text-center mb-8 bg-gradient-brasil bg-clip-text text-transparent">
           Explore Destinos no Mapa
         </h2>
-        <MapaInterativo />
+        {isMapVisible && (
+          <Suspense fallback={<div className="text-center">Carregando mapa...</div>}>
+            <MapaInterativo />
+          </Suspense>
+        )}
       </div>
       <ExperienciasSection />
       <ParceirosSection />


### PR DESCRIPTION
## Summary
- lazy load MapaInterativo component with React.lazy
- wrap map in Suspense fallback and mount only when in view via IntersectionObserver

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 5 errors, 7 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b8dfd016c48322a616c8e5aec2e573