### PR TITLE
refactor: use OptimizedImage for travel packages

### DIFF
--- a/src/pages/Viagens.tsx
+++ b/src/pages/Viagens.tsx
@@ -11,6 +11,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Plus, Calendar, Users, DollarSign, MapPin, Star, Edit, Trash2 } from "lucide-react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import { OptimizedImage } from "@/components/ui/optimized-image";
 
 const packagedTrips = [
   {
@@ -353,10 +354,11 @@ const Viagens = () => {
               {packagedTrips.map((trip) => (
                 <Card key={trip.id} className="overflow-hidden hover:shadow-primary transition-shadow duration-300 group">
                   <div className="relative h-48 overflow-hidden">
-                    <img 
-                      src={trip.image} 
+                    <OptimizedImage
+                      src={trip.image}
                       alt={`Pacote ${trip.title}`}
                       className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                      lazy
                     />
                     <div className="absolute top-3 right-3">
                       <Badge variant="secondary" className="bg-white/90 text-primary">


### PR DESCRIPTION
## Summary
- use `OptimizedImage` for travel package images in Viagens page

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in src/components/ui/textarea.tsx, unexpected any in src/pages/Auth.tsx, @typescript-eslint/no-require-imports in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dda661c883228418114f6f81bdae