### PR TITLE
chore: SPA links, SEO por página, sitemap/robots, assets e env Supabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -71,3 +71,16 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Environment
+
+Configure the following variables in a `.env` file before running the project:
+
+```
+VITE_SUPABASE_URL=
+VITE_SUPABASE_PUBLISHABLE_KEY=
+```
+
+`public/sitemap.xml` usa `{BASE_URL}` como placeholder. Substitua pelo domínio final durante o deploy, assim como o `href` canônico em `index.html`.
+
+> **Nota:** Ative Row Level Security (RLS) no Supabase e mantenha as chaves fora do repositório.

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,6 +7,8 @@
     <meta name="description" content="Aventuras únicas em destinos inexplorados do Brasil. Trilhas épicas, surf em praias virgens e experiências que vão marcar sua vida. Descubra o Brasil secreto com a TripNation." />
     <meta name="keywords" content="viagem brasil, aventura, trilha, surf, escalada, mountain bike, destinos secretos, turismo aventura" />
     <meta name="author" content="TripNation" />
+    <meta name="theme-color" content="#0ea5a3" />
+    <link rel="canonical" href="https://SEU-DOMINIO/" />
 
     <meta property="og:title" content="TripNation - Descubra o Brasil Secreto" />
     <meta property="og:description" content="Aventuras únicas em destinos inexplorados do Brasil. Trilhas épicas, surf em praias virgens e experiências que vão marcar sua vida." />

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.61.1",
+    "react-helmet-async": "^1.3.0",
     "react-resizable-panels": "^2.1.9",
     "react-router-dom": "^6.30.1",
     "recharts": "^2.15.4",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,3 +12,4 @@ Allow: /
 
 User-agent: *
 Allow: /
+Sitemap: /sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>{BASE_URL}/</loc></url>
+  <url><loc>{BASE_URL}/viagens</loc></url>
+  <url><loc>{BASE_URL}/comunidade</loc></url>
+  <url><loc>{BASE_URL}/avaliacoes</loc></url>
+  <url><loc>{BASE_URL}/chat</loc></url>
+  <url><loc>{BASE_URL}/perfil</loc></url>
+  <url><loc>{BASE_URL}/sobre</loc></url>
+</urlset>

--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Send } from "lucide-react";
+import carla from "@/assets/carla-mendes-profile.jpg";
 
 interface ChatModalProps {
   isOpen: boolean;
@@ -56,7 +57,7 @@ const ChatModal = ({ isOpen, onOpenChange }: ChatModalProps) => {
         <DialogHeader className="p-4 border-b bg-gradient-brasil text-white">
           <div className="flex items-center space-x-3">
             <Avatar className="h-10 w-10">
-              <AvatarImage src="/src/assets/carla-mendes-profile.jpg" alt="Lucas" />
+              <AvatarImage src={carla} alt="Lucas" />
               <AvatarFallback className="bg-white text-primary font-semibold">LC</AvatarFallback>
             </Avatar>
             <div>
@@ -101,12 +102,13 @@ const ChatModal = ({ isOpen, onOpenChange }: ChatModalProps) => {
               onKeyPress={handleKeyPress}
               className="flex-1"
             />
-            <Button 
+            <Button
               onClick={handleSendMessage}
               size="icon"
               className="bg-gradient-brasil hover:opacity-90 transition-opacity"
+              aria-label="Enviar mensagem"
             >
-              <Send className="h-4 w-4" />
+              <Send aria-hidden="true" className="h-4 w-4" />
             </Button>
           </div>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import { MapPin, Instagram, Facebook, Youtube } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
 
 const Footer = () => {
   return (
@@ -10,7 +11,7 @@ const Footer = () => {
           <div className="md:col-span-2">
             <div className="flex items-center space-x-2 mb-4">
               <div className="bg-gradient-brasil p-2 rounded-lg">
-                <MapPin className="w-6 h-6 text-white" />
+                <MapPin aria-hidden="true" className="w-6 h-6 text-white" />
               </div>
               <span className="text-2xl font-bold bg-gradient-brasil bg-clip-text text-transparent">
                 TripNation
@@ -21,14 +22,29 @@ const Footer = () => {
               Sua próxima aventura épica está aqui.
             </p>
             <div className="flex space-x-4">
-              <Button variant="ghost" size="icon" className="text-background hover:text-primary hover:bg-background/10">
-                <Instagram className="w-5 h-5" />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-background hover:text-primary hover:bg-background/10"
+                aria-label="Instagram"
+              >
+                <Instagram aria-hidden="true" className="w-5 h-5" />
               </Button>
-              <Button variant="ghost" size="icon" className="text-background hover:text-primary hover:bg-background/10">
-                <Facebook className="w-5 h-5" />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-background hover:text-primary hover:bg-background/10"
+                aria-label="Facebook"
+              >
+                <Facebook aria-hidden="true" className="w-5 h-5" />
               </Button>
-              <Button variant="ghost" size="icon" className="text-background hover:text-primary hover:bg-background/10">
-                <Youtube className="w-5 h-5" />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-background hover:text-primary hover:bg-background/10"
+                aria-label="YouTube"
+              >
+                <Youtube aria-hidden="true" className="w-5 h-5" />
               </Button>
             </div>
           </div>
@@ -37,10 +53,26 @@ const Footer = () => {
           <div>
             <h4 className="font-bold mb-4 text-yellow">Explorar</h4>
             <ul className="space-y-2">
-              <li><a href="#destinos" className="text-background/80 hover:text-yellow transition-colors">Destinos</a></li>
-              <li><a href="#experiencias" className="text-background/80 hover:text-yellow transition-colors">Experiências</a></li>
-              <li><a href="#blog" className="text-background/80 hover:text-yellow transition-colors">Blog</a></li>
-              <li><a href="#ofertas" className="text-background/80 hover:text-yellow transition-colors">Ofertas</a></li>
+              <li>
+                <a href="#destinos" className="text-background/80 hover:text-yellow transition-colors">
+                  Destinos
+                </a>
+              </li>
+              <li>
+                <a href="#experiencias" className="text-background/80 hover:text-yellow transition-colors">
+                  Experiências
+                </a>
+              </li>
+              <li>
+                <Link to="/" className="text-background/80 hover:text-yellow transition-colors">
+                  Blog
+                </Link>
+              </li>
+              <li>
+                <Link to="/viagens" className="text-background/80 hover:text-yellow transition-colors">
+                  Ofertas
+                </Link>
+              </li>
             </ul>
           </div>
 
@@ -48,10 +80,26 @@ const Footer = () => {
           <div>
             <h4 className="font-bold mb-4 text-yellow">Suporte</h4>
             <ul className="space-y-2">
-              <li><a href="/sobre" className="text-background/80 hover:text-yellow transition-colors">Sobre nós</a></li>
-              <li><a href="#contato" className="text-background/80 hover:text-yellow transition-colors">Contato</a></li>
-              <li><a href="#faq" className="text-background/80 hover:text-yellow transition-colors">FAQ</a></li>
-              <li><a href="#termos" className="text-background/80 hover:text-yellow transition-colors">Termos</a></li>
+              <li>
+                <Link to="/sobre" className="text-background/80 hover:text-yellow transition-colors">
+                  Sobre nós
+                </Link>
+              </li>
+              <li>
+                <Link to="/sobre" className="text-background/80 hover:text-yellow transition-colors">
+                  Contato
+                </Link>
+              </li>
+              <li>
+                <Link to="/sobre" className="text-background/80 hover:text-yellow transition-colors">
+                  FAQ
+                </Link>
+              </li>
+              <li>
+                <Link to="/sobre" className="text-background/80 hover:text-yellow transition-colors">
+                  Termos
+                </Link>
+              </li>
             </ul>
           </div>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Menu, Search, MapPin } from "lucide-react";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -12,39 +13,47 @@ const Header = () => {
           {/* Logo */}
           <div className="flex items-center space-x-2">
             <div className="bg-gradient-brasil p-2 rounded-lg">
-              <MapPin className="w-6 h-6 text-white" />
+              <MapPin aria-hidden="true" className="w-6 h-6 text-white" />
             </div>
-            <a href="/" className="text-2xl font-bold bg-gradient-brasil bg-clip-text text-transparent hover:opacity-80 transition-opacity">
+            <Link
+              to="/"
+              className="text-2xl font-bold bg-gradient-brasil bg-clip-text text-transparent hover:opacity-80 transition-opacity"
+            >
               TripNation
-            </a>
+            </Link>
           </div>
 
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center space-x-8">
-            <a href="/viagens" className="text-foreground hover:text-primary transition-colors font-medium">
+            <Link to="/viagens" className="text-foreground hover:text-primary transition-colors font-medium">
               Viagens
-            </a>
-            <a href="/comunidade" className="text-foreground hover:text-primary transition-colors font-medium">
+            </Link>
+            <Link to="/comunidade" className="text-foreground hover:text-primary transition-colors font-medium">
               Comunidade
-            </a>
-            <a href="/avaliacoes" className="text-foreground hover:text-primary transition-colors font-medium">
+            </Link>
+            <Link to="/avaliacoes" className="text-foreground hover:text-primary transition-colors font-medium">
               Avaliações
-            </a>
-            <a href="/chat" className="text-foreground hover:text-primary transition-colors font-medium">
+            </Link>
+            <Link to="/chat" className="text-foreground hover:text-primary transition-colors font-medium">
               Chat
-            </a>
-            <a href="/perfil" className="text-foreground hover:text-primary transition-colors font-medium">
+            </Link>
+            <Link to="/perfil" className="text-foreground hover:text-primary transition-colors font-medium">
               Perfil
-            </a>
+            </Link>
           </nav>
 
           {/* Actions */}
           <div className="flex items-center space-x-4">
-            <Button variant="ghost" size="icon" className="hidden md:flex">
-              <Search className="w-5 h-5" />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="hidden md:flex"
+              aria-label="Pesquisar"
+            >
+              <Search aria-hidden="true" className="w-5 h-5" />
             </Button>
             <Button asChild className="hidden md:flex bg-gradient-brasil hover:opacity-90 transition-opacity">
-              <a href="/auth">Entrar / Cadastrar</a>
+              <Link to="/auth">Entrar / Cadastrar</Link>
             </Button>
             
             {/* Mobile Menu Button */}
@@ -53,8 +62,9 @@ const Header = () => {
               size="icon"
               className="md:hidden"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
+              aria-label="Abrir menu"
             >
-              <Menu className="w-5 h-5" />
+              <Menu aria-hidden="true" className="w-5 h-5" />
             </Button>
           </div>
         </div>
@@ -63,27 +73,27 @@ const Header = () => {
         {isMenuOpen && (
           <nav className="md:hidden mt-4 pt-4 border-t border-border">
             <div className="flex flex-col space-y-4">
-              <a href="/viagens" className="text-foreground hover:text-primary transition-colors font-medium">
+              <Link to="/viagens" className="text-foreground hover:text-primary transition-colors font-medium">
                 Viagens
-              </a>
-              <a href="/comunidade" className="text-foreground hover:text-primary transition-colors font-medium">
+              </Link>
+              <Link to="/comunidade" className="text-foreground hover:text-primary transition-colors font-medium">
                 Comunidade
-              </a>
-              <a href="/avaliacoes" className="text-foreground hover:text-primary transition-colors font-medium">
+              </Link>
+              <Link to="/avaliacoes" className="text-foreground hover:text-primary transition-colors font-medium">
                 Avaliações
-              </a>
-              <a href="/chat" className="text-foreground hover:text-primary transition-colors font-medium">
+              </Link>
+              <Link to="/chat" className="text-foreground hover:text-primary transition-colors font-medium">
                 Chat
-              </a>
-              <a href="/perfil" className="text-foreground hover:text-primary transition-colors font-medium">
+              </Link>
+              <Link to="/perfil" className="text-foreground hover:text-primary transition-colors font-medium">
                 Perfil
-              </a>
+              </Link>
               <div className="flex space-x-2 pt-2">
-                <Button variant="ghost" size="icon">
-                  <Search className="w-5 h-5" />
+                <Button variant="ghost" size="icon" aria-label="Pesquisar">
+                  <Search aria-hidden="true" className="w-5 h-5" />
                 </Button>
                 <Button asChild className="flex-1 bg-gradient-brasil hover:opacity-90 transition-opacity">
-                  <a href="/auth">Entrar / Cadastrar</a>
+                  <Link to="/auth">Entrar / Cadastrar</Link>
                 </Button>
               </div>
             </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -43,13 +43,14 @@ const Hero = () => {
               onClick={() => navigate('/viagens')}
             >
               Encontre sua viagem
-              <ArrowRight className="ml-2 w-5 h-5" />
+              <ArrowRight aria-hidden="true" className="ml-2 w-5 h-5" />
             </Button>
-            
-            <Button 
-              variant="outline" 
-              size="lg" 
+
+            <Button
+              variant="outline"
+              size="lg"
               className="bg-white/10 border-white/30 hover:bg-white/20 text-white text-lg px-8 py-3 backdrop-blur-sm"
+              onClick={() => navigate('/comunidade')}
             >
               Ver Grupos Abertos
             </Button>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,0 +1,17 @@
+import { Helmet } from 'react-helmet-async';
+
+interface SEOProps {
+  title: string;
+  description: string;
+}
+
+const SEO = ({ title, description }: SEOProps) => (
+  <Helmet>
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+  </Helmet>
+);
+
+export default SEO;

--- a/src/components/ViagensGrupo.tsx
+++ b/src/components/ViagensGrupo.tsx
@@ -56,7 +56,7 @@ const ViagensGrupo = () => {
   const navigate = useNavigate();
   
   return (
-    <section className="py-16 bg-muted/30">
+    <section id="destinos" className="py-16 bg-muted/30">
       <div className="container mx-auto px-4">
         <div className="text-center mb-12">
           <h2 className="text-3xl md:text-4xl font-bold mb-4 bg-gradient-brasil bg-clip-text text-transparent">
@@ -90,7 +90,7 @@ const ViagensGrupo = () => {
               
               <CardContent className="p-4">
                 <div className="flex items-start gap-2 mb-2">
-                  <MapPin className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
+                  <MapPin aria-hidden="true" className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
                   <h3 className="font-semibold text-sm leading-tight">{viagem.local}</h3>
                 </div>
                 
@@ -98,7 +98,7 @@ const ViagensGrupo = () => {
                 
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <Users className="w-4 h-4" />
+                    <Users aria-hidden="true" className="w-4 h-4" />
                     <span>{viagem.interessados}/{viagem.vagas} pessoas</span>
                   </div>
                   <div className="w-16 h-1 bg-muted rounded-full overflow-hidden">

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://mtcrrjocygobnhczclwk.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im10Y3Jyam9jeWdvYm5oY3pjbHdrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyMTcxOTAsImV4cCI6MjA3MDc5MzE5MH0.SgMC6lyhrOosjTDEJ_Bx2qVnZUq5BodcalgMoZX2Roc";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL!;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY!;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,11 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { HelmetProvider } from 'react-helmet-async';
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <HelmetProvider>
+    <App />
+  </HelmetProvider>
+);
+

--- a/src/pages/Avaliacoes.tsx
+++ b/src/pages/Avaliacoes.tsx
@@ -7,6 +7,7 @@ import { Star, Filter, ChevronDown } from "lucide-react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import AvaliacaoModal from "@/components/AvaliacaoModal";
+import SEO from "@/components/SEO";
 
 const mockReviews = [
   {
@@ -82,6 +83,7 @@ const Avaliacoes = () => {
 
   return (
     <div className="min-h-screen bg-background">
+      <SEO title="Avaliações | TripNation" description="Leia avaliações de aventuras e destinos pelo Brasil." />
       <Header />
       
       <main className="container mx-auto px-4 py-8">

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Send, Phone, Video, MoreVertical } from "lucide-react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 
 const mockMessages = [
   {
@@ -80,6 +81,7 @@ const Chat = () => {
 
   return (
     <div className="min-h-screen bg-background">
+      <SEO title="Chat | TripNation" description="Converse com outros aventureiros em tempo real." />
       <Header />
       
       <main className="container mx-auto px-4 py-8">
@@ -163,8 +165,8 @@ const Chat = () => {
                   onKeyPress={handleKeyPress}
                   className="flex-1"
                 />
-                <Button onClick={handleSendMessage} size="icon">
-                  <Send className="h-4 w-4" />
+                <Button onClick={handleSendMessage} size="icon" aria-label="Enviar mensagem">
+                  <Send aria-hidden="true" className="h-4 w-4" />
                 </Button>
               </div>
             </div>

--- a/src/pages/Comunidade.tsx
+++ b/src/pages/Comunidade.tsx
@@ -8,6 +8,7 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import amanhecerSerraImage from "@/assets/amanhecer-serra-estrelas.jpg";
 import surfPraiaImage from "@/assets/surf-praia-atoba.jpg";
+import SEO from "@/components/SEO";
 
 const mockPosts = [
   {
@@ -53,6 +54,7 @@ const Comunidade = () => {
 
   return (
     <div className="min-h-screen bg-background">
+      <SEO title="Comunidade | TripNation" description="Veja posts e conecte-se com aventureiros pelo Brasil." />
       <Header />
       
       <main className="container mx-auto px-4 py-8">
@@ -106,8 +108,12 @@ const Comunidade = () => {
                           className="w-full h-64 object-cover rounded-lg"
                         />
                         <div className="absolute inset-0 flex items-center justify-center">
-                          <Button size="icon" className="h-16 w-16 rounded-full bg-black/50 hover:bg-black/70">
-                            <PlayCircle className="h-8 w-8 text-white" />
+                          <Button
+                            size="icon"
+                            className="h-16 w-16 rounded-full bg-black/50 hover:bg-black/70"
+                            aria-label="Reproduzir vídeo"
+                          >
+                            <PlayCircle aria-hidden="true" className="h-8 w-8 text-white" />
                           </Button>
                         </div>
                       </div>
@@ -122,15 +128,15 @@ const Comunidade = () => {
                         onClick={() => handleLike(post.id)}
                         className={likedPosts.includes(post.id) ? "text-red-500" : ""}
                       >
-                        <Heart className={`h-4 w-4 mr-1 ${likedPosts.includes(post.id) ? "fill-current" : ""}`} />
+                        <Heart aria-hidden="true" className={`h-4 w-4 mr-1 ${likedPosts.includes(post.id) ? "fill-current" : ""}`} />
                         {post.likes + (likedPosts.includes(post.id) ? 1 : 0)}
                       </Button>
                       <Button variant="ghost" size="sm">
-                        <MessageCircle className="h-4 w-4 mr-1" />
+                        <MessageCircle aria-hidden="true" className="h-4 w-4 mr-1" />
                         {post.comments}
                       </Button>
                       <Button variant="ghost" size="sm">
-                        <Share2 className="h-4 w-4 mr-1" />
+                        <Share2 aria-hidden="true" className="h-4 w-4 mr-1" />
                         Compartilhar
                       </Button>
                     </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,10 +9,12 @@ import ParceirosSection from "@/components/ParceirosSection";
 import CtaComunidade from "@/components/CtaComunidade";
 import Footer from "@/components/Footer";
 import MapaInterativo from "@/components/MapaInterativo";
+import SEO from "@/components/SEO";
 
 const Index = () => {
   return (
     <div className="min-h-screen">
+      <SEO title="TripNation | Aventuras pelo Brasil" description="Conecte-se a pessoas, destinos e aventuras inesquecíveis." />
       <Header />
       <Hero />
       <ViagensGrupo />

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -7,6 +7,7 @@ import { MapPin, Calendar, Trophy, Star, Edit, Share2 } from "lucide-react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import carlaProfile from "@/assets/carla-mendes-profile.jpg";
+import SEO from "@/components/SEO";
 const mockUser = {
   name: "Carla Mendes",
   bio: "Aventureira apaixonada por trilhas e ciclismo. Sempre em busca de novos destinos para explorar no Brasil!",
@@ -36,6 +37,7 @@ const mockUser = {
 };
 const Perfil = () => {
   return <div className="min-h-screen bg-background">
+      <SEO title="Perfil | TripNation" description="Gerencie seu perfil e veja suas conquistas." />
       <Header />
       
       <main className="container mx-auto mt-4 my-[20px] px-[24px] py-[76px]">
@@ -52,7 +54,7 @@ const Perfil = () => {
                   <div className="flex items-center space-x-4 mb-2">
                     <h1 className="text-3xl font-bold">{mockUser.name}</h1>
                     <Badge className="bg-gradient-to-r from-laranja to-amarelo text-white">
-                      <Trophy className="w-3 h-3 mr-1" />
+                      <Trophy aria-hidden="true" className="w-3 h-3 mr-1" />
                       {mockUser.engagementPoints} pontos
                     </Badge>
                   </div>
@@ -61,22 +63,22 @@ const Perfil = () => {
                   
                   <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
                     <div className="flex items-center">
-                      <MapPin className="w-4 h-4 mr-1" />
+                      <MapPin aria-hidden="true" className="w-4 h-4 mr-1" />
                       {mockUser.location}
                     </div>
                     <div className="flex items-center">
-                      <Calendar className="w-4 h-4 mr-1" />
+                      <Calendar aria-hidden="true" className="w-4 h-4 mr-1" />
                       Desde {mockUser.joinDate}
                     </div>
                   </div>
                 </div>
                 
                 <div className="flex space-x-2">
-                  <Button variant="outline" size="icon">
-                    <Share2 className="h-4 w-4" />
+                  <Button variant="outline" size="icon" aria-label="Compartilhar perfil">
+                    <Share2 aria-hidden="true" className="h-4 w-4" />
                   </Button>
                   <Button>
-                    <Edit className="h-4 w-4 mr-2" />
+                    <Edit aria-hidden="true" className="h-4 w-4 mr-2" />
                     Editar Perfil
                   </Button>
                 </div>
@@ -128,15 +130,15 @@ const Perfil = () => {
               </CardHeader>
               <CardContent className="space-y-3">
                 <div className="flex items-center space-x-2">
-                  <Trophy className="w-5 h-5 text-yellow-500" />
+                  <Trophy aria-hidden="true" className="w-5 h-5 text-yellow-500" />
                   <span className="text-sm">Primeira Trilha</span>
                 </div>
                 <div className="flex items-center space-x-2">
-                  <Trophy className="w-5 h-5 text-yellow-500" />
+                  <Trophy aria-hidden="true" className="w-5 h-5 text-yellow-500" />
                   <span className="text-sm">10 Destinos</span>
                 </div>
                 <div className="flex items-center space-x-2">
-                  <Trophy className="w-5 h-5 text-yellow-500" />
+                  <Trophy aria-hidden="true" className="w-5 h-5 text-yellow-500" />
                   <span className="text-sm">Explorador</span>
                 </div>
               </CardContent>
@@ -158,7 +160,9 @@ const Perfil = () => {
                       <div className="flex items-center space-x-1">
                         {Array.from({
                       length: trip.rating
-                    }, (_, i) => <Star key={i} className="w-4 h-4 fill-yellow-400 text-yellow-400" />)}
+                    }, (_, i) => (
+                          <Star key={i} aria-hidden="true" className="w-4 h-4 fill-yellow-400 text-yellow-400" />
+                        ))}
                       </div>
                     </div>
                     {index < mockUser.completedTrips.length - 1 && <Separator className="mt-4" />}

--- a/src/pages/Sobre.tsx
+++ b/src/pages/Sobre.tsx
@@ -3,20 +3,21 @@ import Footer from "@/components/Footer";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { 
-  Leaf, 
-  Users, 
-  Heart, 
-  Globe, 
-  DollarSign, 
-  Crown, 
-  Handshake, 
+import {
+  Leaf,
+  Users,
+  Heart,
+  Globe,
+  DollarSign,
+  Crown,
+  Handshake,
   BarChart3,
   TreePine,
   MapPin,
   Sparkles,
   Target
 } from "lucide-react";
+import SEO from "@/components/SEO";
 
 // Team member photos
 import danielVicente from "@/assets/daniel-vicente.jpg";
@@ -28,22 +29,22 @@ import matheusAnanias from "@/assets/matheus-ananias.jpg";
 const Sobre = () => {
   const diferenciais = [
     {
-      icon: <Leaf className="w-8 h-8 text-green-600" />,
+      icon: <Leaf aria-hidden="true" className="w-8 h-8 text-green-600" />,
       titulo: "Turismo Sustentável",
       descricao: "Descentralizado e com impacto positivo"
     },
     {
-      icon: <Heart className="w-8 h-8 text-red-500" />,
+      icon: <Heart aria-hidden="true" className="w-8 h-8 text-red-500" />,
       titulo: "Experiências Autênticas",
       descricao: "Curadoria local e vivências únicas"
     },
     {
-      icon: <Users className="w-8 h-8 text-blue-600" />,
+      icon: <Users aria-hidden="true" className="w-8 h-8 text-blue-600" />,
       titulo: "Foco no Viajante Solo",
       descricao: "Conexões reais e comunidade acolhedora"
     },
     {
-      icon: <Globe className="w-8 h-8 text-purple-600" />,
+      icon: <Globe aria-hidden="true" className="w-8 h-8 text-purple-600" />,
       titulo: "Comunidade Real",
       descricao: "Rede de viajantes engajados"
     }
@@ -51,22 +52,22 @@ const Sobre = () => {
 
   const modeloNegocio = [
     {
-      icon: <DollarSign className="w-6 h-6 text-green-600" />,
+      icon: <DollarSign aria-hidden="true" className="w-6 h-6 text-green-600" />,
       titulo: "Comissão sobre Reservas",
       descricao: "Revenue share sustentável com parceiros locais"
     },
     {
-      icon: <Crown className="w-6 h-6 text-gold" />,
+      icon: <Crown aria-hidden="true" className="w-6 h-6 text-yellow-500" />,
       titulo: "Planos de Assinatura",
       descricao: "Benefícios exclusivos para viajantes frequentes"
     },
     {
-      icon: <Handshake className="w-6 h-6 text-blue-600" />,
+      icon: <Handshake aria-hidden="true" className="w-6 h-6 text-blue-600" />,
       titulo: "Parcerias Estratégicas",
       descricao: "Transporte, hospedagem, gastronomia e ESG"
     },
     {
-      icon: <BarChart3 className="w-6 h-6 text-purple-600" />,
+      icon: <BarChart3 aria-hidden="true" className="w-6 h-6 text-purple-600" />,
       titulo: "Relatórios de Impacto",
       descricao: "Transparência social e ambiental"
     }
@@ -74,22 +75,22 @@ const Sobre = () => {
 
   const impactos = [
     {
-      icon: <TreePine className="w-6 h-6 text-green-600" />,
+      icon: <TreePine aria-hidden="true" className="w-6 h-6 text-green-600" />,
       titulo: "Preservação Ambiental",
       descricao: "Turismo regenerativo e consciente"
     },
     {
-      icon: <MapPin className="w-6 h-6 text-orange-500" />,
+      icon: <MapPin aria-hidden="true" className="w-6 h-6 text-orange-500" />,
       titulo: "Renda Local",
       descricao: "Fortalecimento de economias regionais"
     },
     {
-      icon: <Users className="w-6 h-6 text-blue-600" />,
+      icon: <Users aria-hidden="true" className="w-6 h-6 text-blue-600" />,
       titulo: "Inclusão Social",
       descricao: "Diversidade e acessibilidade"
     },
     {
-      icon: <Sparkles className="w-6 h-6 text-purple-600" />,
+      icon: <Sparkles aria-hidden="true" className="w-6 h-6 text-purple-600" />,
       titulo: "Transformação Pessoal",
       descricao: "Crescimento através de conexões"
     }
@@ -130,6 +131,7 @@ const Sobre = () => {
 
   return (
     <div className="min-h-screen bg-background">
+      <SEO title="Sobre | TripNation" description="Conheça a TripNation e nossa missão de conectar aventureiros." />
       <Header />
       
       <main className="pt-20">
@@ -169,7 +171,7 @@ const Sobre = () => {
         <section className="py-16 bg-gradient-to-r from-primary/5 to-secondary/5">
           <div className="container mx-auto px-4 text-center">
             <div className="max-w-4xl mx-auto">
-              <Target className="w-16 h-16 mx-auto mb-6 text-primary" />
+              <Target aria-hidden="true" className="w-16 h-16 mx-auto mb-6 text-primary" />
               <h2 className="text-3xl font-bold mb-6">Nossa Missão</h2>
               <div className="bg-gradient-brasil p-8 rounded-2xl">
                 <p className="text-2xl md:text-3xl font-bold text-white">

--- a/src/pages/Viagens.tsx
+++ b/src/pages/Viagens.tsx
@@ -11,6 +11,10 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Plus, Calendar, Users, DollarSign, MapPin, Star, Edit, Trash2 } from "lucide-react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import escaladaImage from "@/assets/escalada-chapada.jpg";
+import surfImage from "@/assets/surf-praia-atoba.jpg";
+import bikeImage from "@/assets/mountain-bike-mata-atlantica.jpg";
+import SEO from "@/components/SEO";
 
 const packagedTrips = [
   {
@@ -19,7 +23,7 @@ const packagedTrips = [
     duration: "3 dias",
     price: "R$ 1.200",
     description: "Inclui guia e hospedagem simples",
-    image: "/src/assets/escalada-chapada.jpg",
+    image: escaladaImage,
     rating: 4.8,
     difficulty: "Médio",
     sport: "Trilha",
@@ -35,7 +39,7 @@ const packagedTrips = [
     duration: "5 dias",
     price: "R$ 2.500",
     description: "Inclui aulas de surf e hospedagem frente-mar",
-    image: "/src/assets/surf-praia-atoba.jpg",
+    image: surfImage,
     rating: 4.9,
     difficulty: "Iniciante",
     sport: "Surf",
@@ -51,7 +55,7 @@ const packagedTrips = [
     duration: "2 dias",
     price: "R$ 900",
     description: "Inclui aluguel de bike e camping",
-    image: "/src/assets/mountain-bike-mata-atlantica.jpg",
+    image: bikeImage,
     rating: 4.7,
     difficulty: "Fácil",
     sport: "Ciclismo",
@@ -119,15 +123,17 @@ const Viagens = () => {
 
   const renderStars = (rating: number) => {
     return Array.from({ length: 5 }, (_, i) => (
-      <Star 
-        key={i} 
-        className={`h-4 w-4 ${i < Math.floor(rating) ? "fill-yellow text-yellow" : "text-muted"}`} 
+      <Star
+        key={i}
+        aria-hidden="true"
+        className={`h-4 w-4 ${i < Math.floor(rating) ? "fill-yellow text-yellow" : "text-muted"}`}
       />
     ));
   };
 
   return (
     <div className="min-h-screen bg-background">
+      <SEO title="Viagens | TripNation" description="Explore pacotes e crie suas próprias viagens pelo Brasil." />
       <Header />
       
       <main className="container mx-auto px-4 py-8">
@@ -148,7 +154,7 @@ const Viagens = () => {
               <Dialog open={isCreateTripOpen} onOpenChange={setIsCreateTripOpen}>
                 <DialogTrigger asChild>
                   <Button className="bg-gradient-brasil hover:opacity-90 transition-opacity">
-                    <Plus className="h-5 w-5 mr-2" />
+                    <Plus aria-hidden="true" className="h-5 w-5 mr-2" />
                     Criar Viagem
                   </Button>
                 </DialogTrigger>
@@ -372,7 +378,7 @@ const Viagens = () => {
                   
                   <CardContent className="p-4">
                     <div className="flex items-start gap-2 mb-2">
-                      <MapPin className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
+                      <MapPin aria-hidden="true" className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
                       <h3 className="font-semibold text-sm leading-tight">{trip.title}</h3>
                     </div>
                     
@@ -380,7 +386,7 @@ const Viagens = () => {
                     
                     <div className="flex items-center justify-between mb-4">
                       <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                        <Users className="w-4 h-4" />
+                        <Users aria-hidden="true" className="w-4 h-4" />
                         <span>8/12 pessoas</span>
                       </div>
                       <div className="w-16 h-1 bg-muted rounded-full overflow-hidden">


### PR DESCRIPTION
- Navegação SPA: `<Link to>` no Header/Footer e `useNavigate` no CTA “Ver Grupos Abertos`.
- Assets via import (Vite) em Viagens e Chat/Avatar (remoção de "/src/assets/...").
- Supabase: uso de `import.meta.env` e `.gitignore` com `.env`.
- SEO por página com `react-helmet-async` + `HelmetProvider`.
- `index.html` com `lang="pt-BR"` e `meta theme-color`.
- `public/sitemap.xml` (placeholder `{BASE_URL}`) e `public/robots.txt` com referência ao sitemap.
- A11y: `aria-hidden` em ícones decorativos; ajuste de cor Tailwind.
- Build validado (`npm run build`). README atualizado com TODOs de deploy.

------
https://chatgpt.com/codex/tasks/task_e_68b8f88e1aa88322835cc1d650b59c5c