### PR TITLE
Limit chat card width

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -89,7 +89,7 @@ const Chat = () => {
       <Header />
       
       <main className="container mx-auto px-4 py-8">
-        <div className="max-w-4xl mx-auto">
+        <div className="w-full max-w-[480px] mx-auto">
           <div className="text-center mb-8">
             <h1 className="text-4xl font-bold bg-gradient-to-r from-laranja to-amarelo bg-clip-text text-transparent mb-4">
               Chat TripNation


### PR DESCRIPTION
## Summary
- restrict the chat layout container to a 480px maximum width to match design expectations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce1681ceb08322879606974adb3ee2