### PR TITLE
Configure Vite base path for subdirectory deployments

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,19 +4,24 @@ import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const base = process.env.VITE_BASE_PATH || "./";
+
+  return {
+    base,
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-}));
+    plugins: [
+      react(),
+      mode === 'development' &&
+      componentTagger(),
+    ].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- configure the Vite build to respect a configurable deployment base path

## Testing
- `npm run build` *(fails: vite not found because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1a99edf88322a380d5fcd2dbfd10