### PR TITLE
Handle CEP loading resets

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -67,7 +67,10 @@ const Auth = () => {
   // Auto-preencher Rua quando CEP tiver 8 dígitos
   useEffect(() => {
     const raw = onlyDigits(cep);
-    if (raw.length !== 8) return;
+    if (raw.length !== 8) {
+      setLoadingCEP(false);
+      return;
+    }
     let cancelled = false;
 
     (async () => {
@@ -88,6 +91,7 @@ const Auth = () => {
 
     return () => {
       cancelled = true;
+      setLoadingCEP(false);
     };
   }, [cep]);
 


### PR DESCRIPTION
## Summary
- ensure ViaCEP lookup resets the loading indicator when the CEP has an invalid length
- reset the CEP loading state when the effect cleans up to clear the UI indicator

## Testing
- npm run lint *(fails: missing dependency @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68ce244c72ec83229811c0e8105f40a9