### PR TITLE
Redireciona /avaliacoes para Comunidade e atualiza navegação

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,6 @@
   <url><loc>{BASE_URL}/</loc></url>
   <url><loc>{BASE_URL}/viagens</loc></url>
   <url><loc>{BASE_URL}/comunidade</loc></url>
-  <url><loc>{BASE_URL}/avaliacoes</loc></url>
   <url><loc>{BASE_URL}/chat</loc></url>
   <url><loc>{BASE_URL}/perfil</loc></url>
   <url><loc>{BASE_URL}/sobre</loc></url>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Suspense, lazy } from "react";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -13,7 +13,6 @@ const NotFound = lazy(() => import("./pages/NotFound"));
 const Auth = lazy(() => import("./pages/Auth"));
 const Viagens = lazy(() => import("./pages/Viagens"));
 const Comunidade = lazy(() => import("./pages/Comunidade"));
-const Avaliacoes = lazy(() => import("./pages/Avaliacoes"));
 const Chat = lazy(() => import("./pages/Chat"));
 const Perfil = lazy(() => import("./pages/Perfil"));
 const Sobre = lazy(() => import("./pages/Sobre"));
@@ -61,7 +60,7 @@ const App = () => (
               <Route path="/auth" element={<Auth />} />
               <Route path="/viagens" element={<Viagens />} />
               <Route path="/comunidade" element={<Comunidade />} />
-              <Route path="/avaliacoes" element={<Avaliacoes />} />
+              <Route path="/avaliacoes" element={<Navigate to="/comunidade" replace />} />
               <Route path="/chat" element={<Chat />} />
               <Route path="/perfil" element={<Perfil />} />
               <Route path="/sobre" element={<Sobre />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,9 +31,6 @@ const Header = () => {
             <Link to="/comunidade" className="text-foreground hover:text-primary transition-colors font-medium">
               Comunidade
             </Link>
-            <Link to="/avaliacoes" className="text-foreground hover:text-primary transition-colors font-medium">
-              Avaliações
-            </Link>
             <Link to="/chat" className="text-foreground hover:text-primary transition-colors font-medium">
               Chat
             </Link>
@@ -78,9 +75,6 @@ const Header = () => {
               </Link>
               <Link to="/comunidade" className="text-foreground hover:text-primary transition-colors font-medium">
                 Comunidade
-              </Link>
-              <Link to="/avaliacoes" className="text-foreground hover:text-primary transition-colors font-medium">
-                Avaliações
               </Link>
               <Link to="/chat" className="text-foreground hover:text-primary transition-colors font-medium">
                 Chat


### PR DESCRIPTION
## Summary
- Redireciona a rota /avaliacoes para reutilizar o conteúdo da página Comunidade, evitando a aba duplicada.
- Remove o link dedicado de "Avaliações" do cabeçalho nas versões desktop e mobile para manter apenas a aba combinada.
- Atualiza o sitemap para deixar de listar o caminho /avaliacoes.

## Testing
- `npm run lint` *(falhou: dependências não instaladas; `npm install` bloqueado pelo registry com erro 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ce33de817c8322a2639f6dcb4b89a3