### PR TITLE
Add Guias link to header navigation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,6 +28,9 @@ const Header = () => {
             <Link to="/viagens" className="text-foreground hover:text-primary transition-colors font-medium">
               Viagens
             </Link>
+            <Link to="/guias" className="text-foreground hover:text-primary transition-colors font-medium">
+              Guias
+            </Link>
             <Link to="/comunidade" className="text-foreground hover:text-primary transition-colors font-medium">
               Comunidade
             </Link>
@@ -72,6 +75,9 @@ const Header = () => {
             <div className="flex flex-col space-y-4">
               <Link to="/viagens" className="text-foreground hover:text-primary transition-colors font-medium">
                 Viagens
+              </Link>
+              <Link to="/guias" className="text-foreground hover:text-primary transition-colors font-medium">
+                Guias
               </Link>
               <Link to="/comunidade" className="text-foreground hover:text-primary transition-colors font-medium">
                 Comunidade


### PR DESCRIPTION
## Summary
- add Guias entry to the desktop navigation menu
- include the Guias link in the mobile navigation menu when expanded

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce3c85bed88322a63fbc5e2d3d24af