### PR TITLE
Fix Atobá surf review images

### DIFF
--- a/src/pages/Comunidade.tsx
+++ b/src/pages/Comunidade.tsx
@@ -136,7 +136,7 @@ const mockReviews: ReviewItem[] = [
     comment:
       "Experiência única! As ondas estavam perfeitas e o instrutor foi excepcional. Recomendo muito para quem quer aprender ou aperfeiçoar o surf.",
     date: "8 Jan 2024",
-    images: [surfPraiaImage, placeholderAvatar]
+    images: [surfPraiaImage]
   },
   {
     type: "avaliacao",


### PR DESCRIPTION
## Summary
- remove the placeholder avatar from the Surf na Praia do Atobá review so only the real surf image thumbnail is shown

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org/react-helmet-async in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3cacf4b08322b718c44f2fc0eacc