### PR TITLE
Add Guias link to header navigation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,6 +28,9 @@ const Header = () => {
             <Link to="/viagens" className="text-foreground hover:text-primary transition-colors font-medium">
               Viagens
             </Link>
+            <Link to="/guias" className="text-foreground hover:text-primary transition-colors font-medium">
+              Guias
+            </Link>
             <Link to="/comunidade" className="text-foreground hover:text-primary transition-colors font-medium">
               Comunidade
             </Link>
@@ -72,6 +75,9 @@ const Header = () => {
             <div className="flex flex-col space-y-4">
               <Link to="/viagens" className="text-foreground hover:text-primary transition-colors font-medium">
                 Viagens
+              </Link>
+              <Link to="/guias" className="text-foreground hover:text-primary transition-colors font-medium">
+                Guias
               </Link>
               <Link to="/comunidade" className="text-foreground hover:text-primary transition-colors font-medium">
                 Comunidade

--- a/src/pages/GuidesPage.tsx
+++ b/src/pages/GuidesPage.tsx
@@ -99,7 +99,7 @@ const GuidesPage = () => {
       />
       <Header />
 
-      <main className="container mx-auto flex-1 px-4 py-10">
+      <main className="container mx-auto flex-1 px-4 pb-16 pt-32">
         <div className="mx-auto max-w-6xl space-y-8">
           <div className="text-center">
             <h1 className="text-4xl font-bold bg-gradient-brasil bg-clip-text text-transparent">Conheça nossos guias</h1>


### PR DESCRIPTION
## Summary
- add Guias entry to the desktop navigation menu
- include the Guias link in the mobile navigation menu when expanded
- increase the top padding on the Guides page so content sits below the fixed header

## Testing
- npm run build *(fails: vite not found because dependencies are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3c85bed88322a63fbc5e2d3d24af