### PR TITLE
Use Trilha do Pico do Horizonte artwork in hero component

### DIFF
--- a/src/assets/trilha-pico-horizonte.svg
+++ b/src/assets/trilha-pico-horizonte.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-label="Arte digital da Trilha do Pico do Horizonte">
+  <defs>
+    <linearGradient id="sky" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#0b1d3a"/>
+      <stop offset="50%" stop-color="#21466f"/>
+      <stop offset="100%" stop-color="#467b9e"/>
+    </linearGradient>
+    <linearGradient id="path" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f6d69b"/>
+      <stop offset="100%" stop-color="#a0712f"/>
+    </linearGradient>
+    <radialGradient id="sun" cx="30%" cy="25%" r="20%">
+      <stop offset="0%" stop-color="#ffe097" stop-opacity="1"/>
+      <stop offset="100%" stop-color="#ffe097" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#sky)"/>
+  <circle cx="480" cy="220" r="160" fill="url(#sun)"/>
+  <path d="M0,900 L200,530 L520,900 Z" fill="#19263e"/>
+  <path d="M260,900 L660,460 L1080,900 Z" fill="#22304f"/>
+  <path d="M820,900 L1220,520 L1600,900 Z" fill="#2d3c63"/>
+  <path d="M880,900 C820,700 860,560 760,400 C700,290 660,220 620,140" fill="none" stroke="rgba(0,0,0,0.35)" stroke-width="130" stroke-linecap="round"/>
+  <path d="M880,900 C820,710 860,570 760,410 C700,300 660,230 620,150" fill="none" stroke="url(#path)" stroke-width="90" stroke-linecap="round"/>
+  <text x="120" y="760" font-size="88" font-family="'Trebuchet MS', 'Montserrat', sans-serif" fill="#f8f3ea" letter-spacing="3">
+    Trilha do Pico do Horizonte
+  </text>
+</svg>

--- a/src/components/hero/PicoDoHorizonteHero.tsx
+++ b/src/components/hero/PicoDoHorizonteHero.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import trilhaPicoHorizonteImage from "@/assets/trilha-pico-horizonte.svg";
+
+type Props = {
+  src?: string; // default: trilha-pico-horizonte.svg
+  alt?: string; // acessibilidade
+  height?: number; // altura em px (ex.: 520)
+  overlay?: boolean; // overlay suave opcional
+  className?: string; // classes extras
+};
+
+const DEFAULT_IMAGE_SRC = trilhaPicoHorizonteImage;
+
+export default function PicoDoHorizonteHero({
+  src = DEFAULT_IMAGE_SRC,
+  alt = "Trilha do Pico do Horizonte, trilha de terra sinuosa levando a um pico ao pôr do sol",
+  height = 520,
+  overlay = false,
+  className = "",
+}: Props) {
+  return (
+    <section
+      className={`relative w-full overflow-hidden ${className}`}
+      style={{ height }}
+      aria-label={alt}
+    >
+      <div
+        className="absolute inset-0 bg-center bg-cover"
+        style={{ backgroundImage: `url('${src}')` }}
+      />
+      {overlay && (
+        <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-black/10 to-transparent pointer-events-none" />
+      )}
+      {/* Sem texto; apenas imagem */}
+    </section>
+  );
+}

--- a/src/pages/Comunidade.tsx
+++ b/src/pages/Comunidade.tsx
@@ -15,7 +15,7 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import amanhecerSerraImage from "@/assets/amanhecer-serra-estrelas.jpg";
 import surfPraiaImage from "@/assets/surf-praia-atoba.jpg";
-import placeholderAvatar from "@/assets/placeholder.svg";
+import trilhaPicoHorizonte from "@/assets/trilha-pico-horizonte.svg";
 import escalaChapada from "@/assets/escalada-chapada.jpg";
 import SEO from "@/components/SEO";
 
@@ -109,7 +109,7 @@ const mockReviews: ReviewItem[] = [
     rating: 5,
     comment: "Passeio incrível, guia muito atencioso",
     date: "15 Jan 2024",
-    images: [placeholderAvatar]
+    images: [trilhaPicoHorizonte]
   },
   {
     type: "avaliacao",


### PR DESCRIPTION
## Summary
- add a Pico do Horizonte hero component that defaults to the new SVG illustration for its background

## Testing
- npm install *(fails: 403 Forbidden fetching react-helmet-async from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3ea3c540832297c17654a6edc268