### PR TITLE
Update guide name to match photo

### DIFF
--- a/src/pages/GuidesPage.tsx
+++ b/src/pages/GuidesPage.tsx
@@ -29,7 +29,7 @@ interface Guide {
 const guides: Guide[] = [
   {
     id: "joao",
-    name: "João Silva",
+    name: "Maria Silva",
     location: "Manaus, AM",
     description: "Especialista em expedições pela floresta amazônica e culturas ribeirinhas.",
     photo: "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=256&q=80"


### PR DESCRIPTION
## Summary
- update the first guide entry to display Maria Silva so the name matches the photo

## Testing
- no tests were run (not required for this change)

------
https://chatgpt.com/codex/tasks/task_e_68cefd15b45c8322a35a848c46931a80