### PR TITLE
Stop opening edit dialog after adding package trip

### DIFF
--- a/src/pages/Viagens.tsx
+++ b/src/pages/Viagens.tsx
@@ -421,7 +421,6 @@ const Viagens = () => {
         title: "Viagem adicionada",
         description: "Essa viagem foi adicionada às suas viagens de interesse."
       });
-      handleOpenEditTrip(createdTrip);
     }
   };
 


### PR DESCRIPTION
## Summary
- remove automatic edit dialog opening after adding an interested package trip

## Testing
- npm run lint *(fails: missing dependency @eslint/js in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2fa21dcc8322b8dbb8011975af0d