### PR TITLE
Atualiza cálculo de custos de viagens e resumo de pagamento

### DIFF
--- a/src/pages/Pagamento.tsx
+++ b/src/pages/Pagamento.tsx
@@ -352,7 +352,7 @@ const Pagamento = () => {
                     <div className="space-y-2 pt-3 border-t">
                       <p className="font-medium text-foreground">Detalhamento de custos</p>
                       <ul className="space-y-2">
-                        {pricingSummary?.items.map(item => (
+                        {pricingSummary?.items?.map(item => (
                           <li key={item.label} className="flex flex-wrap items-center justify-between gap-2">
                             <span>{item.label}</span>
                             <span className="font-medium text-foreground">{formatCurrency(item.amount)}</span>

--- a/src/pages/Viagens.tsx
+++ b/src/pages/Viagens.tsx
@@ -589,11 +589,16 @@ const Viagens = () => {
       sport: trip.sport,
       startDate: trip.startDate,
       endDate: trip.endDate,
-      baseCost: trip.pricing.base ? trip.pricing.base.toString() : "",
-      transportCost: trip.pricing.transport ? trip.pricing.transport.toString() : "",
-      accommodationCost: trip.pricing.accommodation ? trip.pricing.accommodation.toString() : "",
-      activitiesCost: trip.pricing.activities ? trip.pricing.activities.toString() : "",
-      otherCost: trip.pricing.other ? trip.pricing.other.toString() : "",
+      baseCost: trip.pricing.base !== undefined ? String(trip.pricing.base) : "",
+      transportCost:
+        trip.pricing.transport !== undefined ? String(trip.pricing.transport) : "",
+      accommodationCost:
+        trip.pricing.accommodation !== undefined
+          ? String(trip.pricing.accommodation)
+          : "",
+      activitiesCost:
+        trip.pricing.activities !== undefined ? String(trip.pricing.activities) : "",
+      otherCost: trip.pricing.other !== undefined ? String(trip.pricing.other) : "",
       people: trip.people,
       notes: trip.notes,
       isOpen: trip.isOpen
@@ -1082,7 +1087,7 @@ const Viagens = () => {
                   <div className="rounded-lg border p-4">
                     <h4 className="font-semibold mb-3 text-foreground">Investimento</h4>
                     <ul className="space-y-2 text-sm">
-                      {selectedPackagePricing?.items.map(item => (
+                      {selectedPackagePricing?.items?.map(item => (
                         <li key={item.label} className="flex items-center justify-between">
                           <span className="text-muted-foreground">{item.label}</span>
                           <span className="font-medium text-foreground">


### PR DESCRIPTION
## Summary
- substituir o preço textual dos pacotes por uma estrutura numérica com taxas, custos e formatação amigável
- permitir que viagens personalizadas recebam estimativas de custos e exibam totais com fallback "A confirmar"
- recalcular o resumo do checkout aplicando taxa de serviço de 8%, detalhando os itens e melhorando a responsividade mobile

## Testing
- `npm run lint` *(falha: dependências não puderam ser instaladas – `npm install` retornou 403 para react-helmet-async)*

------
https://chatgpt.com/codex/tasks/task_e_68cf336b56d48322ba9de631f09ce883