### PR TITLE
Atualiza imagens femininas das guias Mariana e Luana

### DIFF
--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -19,7 +19,7 @@ export const guides: Guide[] = [
     name: "Mariana Castro",
     location: "Lençóis, BA",
     description: "Conhecedora das trilhas da Chapada Diamantina e apaixonada por fotografia.",
-    photo: "https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=256&q=80"
+    photo: "https://images.unsplash.com/photo-1531891437562-4301cf35b7e4?auto=format&fit=crop&w=256&q=80"
   },
   {
     id: "carlos",
@@ -33,6 +33,6 @@ export const guides: Guide[] = [
     name: "Luana Ribeiro",
     location: "Florianópolis, SC",
     description: "Instrutora de surf e trilhas costeiras com foco em experiências sustentáveis.",
-    photo: "https://images.unsplash.com/photo-1504593811423-6dd665756598?auto=format&fit=crop&w=256&q=80"
+    photo: "https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=256&q=80"
   }
 ];


### PR DESCRIPTION
## Summary
- atualiza as URLs das fotos das guias Mariana e Luana para imagens femininas adequadas no catálogo

## Testing
- `npm run lint` *(falhou: dependência @eslint/js não instalada porque npm install foi bloqueado pelo registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6650b468832285388d4648fcac0a