### PR TITLE
Adjust page top spacing for fixed header

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -88,7 +88,7 @@ const Chat = () => {
       <SEO title="Chat | TripNation" description="Converse com outros aventureiros em tempo real." />
       <Header />
       
-      <main className="container mx-auto px-4 py-8">
+      <main className="container mx-auto px-4 pt-24 pb-8">
         <div className="w-full max-w-[480px] mx-auto">
           <div className="text-center mb-8">
             <h1 className="text-4xl font-bold bg-gradient-to-r from-laranja to-amarelo bg-clip-text text-transparent mb-4">

--- a/src/pages/Comunidade.tsx
+++ b/src/pages/Comunidade.tsx
@@ -301,7 +301,7 @@ const Comunidade = () => {
       <SEO title="Comunidade | TripNation" description="Veja posts e conecte-se com aventureiros pelo Brasil." />
       <Header />
 
-      <main className="container mx-auto px-4 py-8">
+      <main className="container mx-auto px-4 pt-24 pb-8">
         <div className="max-w-2xl mx-auto">
           <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between mb-8">
             <div className="text-center md:text-left md:flex-1">

--- a/src/pages/Pagamento.tsx
+++ b/src/pages/Pagamento.tsx
@@ -124,7 +124,7 @@ const Pagamento = () => {
       />
       <Header />
 
-      <main className="container mx-auto px-4 py-8">
+      <main className="container mx-auto px-4 pt-24 pb-8">
         <div className="max-w-6xl mx-auto">
           <div className="flex items-center justify-between mb-8">
             <div>

--- a/src/pages/Viagens.tsx
+++ b/src/pages/Viagens.tsx
@@ -745,7 +745,7 @@ const Viagens = () => {
       <SEO title="Viagens | TripNation" description="Explore pacotes e crie suas próprias viagens pelo Brasil." />
       <Header />
       
-      <main className="container mx-auto px-4 py-8">
+      <main className="container mx-auto px-4 pt-24 pb-8">
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-8">
             <h1 className="text-4xl font-bold bg-gradient-brasil bg-clip-text text-transparent mb-4">


### PR DESCRIPTION
## Summary
- add consistent top padding to the main content area of the Viagens, Comunidade, Chat, and Pagamento pages to account for the fixed header height

## Testing
- npm run lint *(fails: missing dependency @eslint/js in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6e0eb7e08322b38b0948456c3239