### PR TITLE
Update guide photos to SVG avatars

### DIFF
--- a/src/lib/guides.ts
+++ b/src/lib/guides.ts
@@ -19,7 +19,7 @@ export const guides: Guide[] = [
     name: "Mariana Castro",
     location: "Lençóis, BA",
     description: "Conhecedora das trilhas da Chapada Diamantina e apaixonada por fotografia.",
-    photo: "https://images.unsplash.com/photo-1531891437562-4301cf35b7e4?auto=format&fit=crop&w=256&q=80"
+    photo: "https://avatars.dicebear.com/api/avataaars/mariana-castro.svg"
   },
   {
     id: "carlos",
@@ -33,6 +33,6 @@ export const guides: Guide[] = [
     name: "Luana Ribeiro",
     location: "Florianópolis, SC",
     description: "Instrutora de surf e trilhas costeiras com foco em experiências sustentáveis.",
-    photo: "https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=256&q=80"
+    photo: "https://avatars.dicebear.com/api/avataaars/luana-ribeiro.svg"
   }
 ];


### PR DESCRIPTION
## Summary
- switch Mariana and Luana guide photos to SVG-based female avatars from DiceBear

## Testing
- npm install *(fails: registry access returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7f4ef57c832286848961d1a2f765