### PR TITLE
Point chat avatar to remote SVG

### DIFF
--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Send } from "lucide-react";
-import gustavo from "@/assets/gustavo-martinez.jpg";
 
 interface ChatModalProps {
   isOpen: boolean;
@@ -57,7 +56,10 @@ const ChatModal = ({ isOpen, onOpenChange }: ChatModalProps) => {
         <DialogHeader className="p-4 border-b bg-gradient-brasil text-white">
           <div className="flex items-center space-x-3">
             <Avatar className="h-10 w-10">
-              <AvatarImage src={gustavo} alt="Lucas" />
+              <AvatarImage
+                src="https://cdn.jsdelivr.net/gh/pixelastic/fakeface-svgs/svg/people/male-9.svg"
+                alt="Lucas"
+              />
               <AvatarFallback className="bg-white text-primary font-semibold">LC</AvatarFallback>
             </Avatar>
             <div>


### PR DESCRIPTION
## Summary
- remove the local JPEG import from the chat modal avatar
- configure the chat specialist avatar to use a hosted male SVG illustration instead

## Testing
- npm install *(fails: registry returned 403 for react-helmet-async)*
- npm run lint *(fails: missing @eslint/js because install step could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7fc477488322af1d45d98a51c5aa