### PR TITLE
Remove community stats section from CTA

### DIFF
--- a/src/components/CtaComunidade.tsx
+++ b/src/components/CtaComunidade.tsx
@@ -13,31 +13,11 @@ const CtaComunidade = () => {
       
       <div className="container mx-auto px-4 relative">
         <div className="max-w-4xl mx-auto text-center text-white">
-          <h2 className="text-4xl md:text-5xl font-bold mb-6 leading-tight">
-            Faça Parte da Maior Comunidade de 
+          <h2 className="text-4xl md:text-5xl font-bold mb-12 leading-tight">
+            Faça Parte da Maior Comunidade de
             <span className="bg-gradient-sunset bg-clip-text text-transparent"> Aventureiros </span>
             do Brasil
           </h2>
-          
-          <p className="text-xl md:text-2xl mb-12 text-white/90 max-w-2xl mx-auto leading-relaxed">
-            Mais de 50.000 aventureiros já fazem parte da TripNation. Sua próxima aventura te espera!
-          </p>
-
-          {/* Stats */}
-          <div className="grid grid-cols-3 gap-8 max-w-md mx-auto mb-12">
-            <div className="text-center">
-              <div className="text-2xl font-bold text-yellow">50k+</div>
-              <div className="text-sm text-white/80">Aventureiros</div>
-            </div>
-            <div className="text-center">
-              <div className="text-2xl font-bold text-yellow">150+</div>
-              <div className="text-sm text-white/80">Destinos</div>
-            </div>
-            <div className="text-center">
-              <div className="text-2xl font-bold text-yellow">98%</div>
-              <div className="text-sm text-white/80">Satisfação</div>
-            </div>
-          </div>
 
           {/* CTAs */}
           <div className="flex justify-center">


### PR DESCRIPTION
## Summary
- remove the community paragraph and stats block from the CTA component
- increase the heading's bottom margin to keep spacing before the call-to-action button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf8e45a63c83228376b11dfebbbfa0